### PR TITLE
fixed issue with CP assets loading causing error on tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Article Editor for Craft CMS
 
+## v3.1.1 - 2024-07-19
+
+### Fixed
+- Issue where the cp assets are causing a conflict with tabs in the admin
+
 ## v3.1.0 - 2024-03-11
 
 ### Fixed

--- a/src/assets/EditorAssets.php
+++ b/src/assets/EditorAssets.php
@@ -3,8 +3,8 @@
 namespace creativeorange\craft\article\assets;
 
 use craft\web\AssetBundle;
-use craft\web\assets\cp\CpAsset;
 use creativeorange\craft\article\Plugin;
+use yii\web\JqueryAsset;
 
 class EditorAssets extends AssetBundle
 {
@@ -25,7 +25,7 @@ class EditorAssets extends AssetBundle
         parent::init();
 
         $this->depends = [
-            CpAsset::class,
+            JqueryAsset::class,
         ];
 
         $this->js = [


### PR DESCRIPTION
The CP assets have been reverted back to Jquery assets due to major issue with tabs in the admin.